### PR TITLE
Docker-build fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,4 @@ pictures/
 .github/
 bibles/json-bibles/csb.json
 bibles/json-bibles/net.json
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ bibles/json-bibles/nlt.json
 bibles/json-bibles/nlt.json.pbz2
 bibles/json-bibles/rsv.json
 bibles/json-bibles/rsv.json.pbz2
+/docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ self_hosted_bible.egg-info/
 notes.txt
 bibles/convert.py
 tests/speedtest.py
+.gitignore
 
 bibles/json-bibles/amp.json
 bibles/json-bibles/amp.json.pbz2

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY --chmod=0755 . .
 
 EXPOSE 5000
 
+STOPSIGNAL SIGKILL
 CMD [ "/usr/src/app/daemon.sh" ]
 VOLUME /usr/src/app/bibles/json-bibles
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD wget http://localhost:5000/health -q -O - > /dev/null 2>&1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A self-hosted webapp of various Bible versions including the KJV, ESV, and ASV.
 |:------------:|:---------:|--------|
 |    x86-64    |     ✅     | latest |
 |   arm64v8    |     ✅     | latest |
-|   arm32v7    |     ✅     | latest |
 
 ## Examples
 *Note: Screen shots taken in dark mode <br>

--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 build-and-push:
-	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag samhaswon/self-hosted-bible:latest .
+	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag samhaswon/self-hosted-bible:latest .


### PR DESCRIPTION
Removed ARMv7 support due to Brotli compression. The Pip install fails due to it, but could be readded if an upstream change fixes this.

Here's the error:
```shell
211.2   error: subprocess-exited-with-error
211.2
211.2   × python setup.py bdist_wheel did not run successfully.
211.2   │ exit code: 1
211.2   ╰─> [75 lines of output]
211.2       /usr/local/lib/python3.11/site-packages/setuptools/dist.py:771: UserWarning: Usage of dash-separated 'build-base' will not be supported in future versions. Please use the u
nderscore name 'build_base' instead
211.2         warnings.warn(
211.2       running bdist_wheel
211.2       running build
211.2       running build_py
211.2       creating bin
211.2       creating bin/lib.linux-armv7l-cpython-311
211.2       copying python/brotli.py -> bin/lib.linux-armv7l-cpython-311
211.2       running build_ext
211.2       building '_brotli' extension
211.2       creating bin/temp.linux-armv7l-cpython-311
211.2       creating bin/temp.linux-armv7l-cpython-311/c
211.2       creating bin/temp.linux-armv7l-cpython-311/c/common
211.2       creating bin/temp.linux-armv7l-cpython-311/c/dec
211.2       creating bin/temp.linux-armv7l-cpython-311/c/enc
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/common/constants.c -o bin/temp.linux-armv7l-cpython-311/c/common/con
stants.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/common/context.c -o bin/temp.linux-armv7l-cpython-311/c/common/conte
xt.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/common/dictionary.c -o bin/temp.linux-armv7l-cpython-311/c/common/di
ctionary.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/common/platform.c -o bin/temp.linux-armv7l-cpython-311/c/common/plat
form.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/common/transform.c -o bin/temp.linux-armv7l-cpython-311/c/common/tra
nsform.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/dec/bit_reader.c -o bin/temp.linux-armv7l-cpython-311/c/dec/bit_read
er.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/dec/decode.c -o bin/temp.linux-armv7l-cpython-311/c/dec/decode.o    
211.2       c/dec/decode.c:2036:41: warning: argument 2 of type 'const uint8_t *' {aka 'const unsigned char *'} declared as a pointer [-Wvla-parameter]
211.2        2036 |     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
211.2             |                          ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
211.2       In file included from c/dec/decode.c:7:
211.2       c/include/brotli/decode.h:204:19: note: previously declared as a variable length array 'const uint8_t[encoded_size]' {aka 'const unsigned char[encoded_size]'}
211.2         204 |     const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
211.2             |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
211.2       c/dec/decode.c:2037:14: warning: argument 4 of type 'uint8_t *' {aka 'unsigned char *'} declared as a pointer [-Wvla-parameter]
211.2        2037 |     uint8_t* decoded_buffer) {
211.2             |     ~~~~~~~~~^~~~~~~~~~~~~~
211.2       c/include/brotli/decode.h:206:13: note: previously declared as a variable length array 'uint8_t[*decoded_size]' {aka 'unsigned char[*decoded_size]'}
211.2         206 |     uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
211.2             |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/dec/huffman.c -o bin/temp.linux-armv7l-cpython-311/c/dec/huffman.o  
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/dec/state.c -o bin/temp.linux-armv7l-cpython-311/c/dec/state.o      
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/backward_references.c -o bin/temp.linux-armv7l-cpython-311/c/enc
/backward_references.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/backward_references_hq.c -o bin/temp.linux-armv7l-cpython-311/c/
enc/backward_references_hq.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/bit_cost.c -o bin/temp.linux-armv7l-cpython-311/c/enc/bit_cost.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/block_splitter.c -o bin/temp.linux-armv7l-cpython-311/c/enc/bloc
k_splitter.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/brotli_bit_stream.c -o bin/temp.linux-armv7l-cpython-311/c/enc/b
rotli_bit_stream.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/cluster.c -o bin/temp.linux-armv7l-cpython-311/c/enc/cluster.o  
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/command.c -o bin/temp.linux-armv7l-cpython-311/c/enc/command.o  
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/compress_fragment.c -o bin/temp.linux-armv7l-cpython-311/c/enc/c
ompress_fragment.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/compress_fragment_two_pass.c -o bin/temp.linux-armv7l-cpython-31
1/c/enc/compress_fragment_two_pass.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/dictionary_hash.c -o bin/temp.linux-armv7l-cpython-311/c/enc/dic
tionary_hash.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/encode.c -o bin/temp.linux-armv7l-cpython-311/c/enc/encode.o    
211.2       c/enc/encode.c:1473:20: warning: argument 5 of type 'const uint8_t *' {aka 'const unsigned char *'} declared as a pointer [-Wvla-parameter]
211.2        1473 |     const uint8_t* input_buffer, size_t* encoded_size,
211.2             |     ~~~~~~~~~~~~~~~^~~~~~~~~~~~
211.2       In file included from c/enc/encode.c:9:
211.2       c/include/brotli/encode.h:314:19: note: previously declared as a variable length array 'const uint8_t[input_size]' {aka 'const unsigned char[input_size]'}
211.2         314 |     const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
211.2             |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
211.2       c/enc/encode.c:1474:14: warning: argument 7 of type 'uint8_t *' {aka 'unsigned char *'} declared as a pointer [-Wvla-parameter]
211.2        1474 |     uint8_t* encoded_buffer) {
211.2             |     ~~~~~~~~~^~~~~~~~~~~~~~
211.2       c/include/brotli/encode.h:316:13: note: previously declared as a variable length array 'uint8_t[*encoded_size]' {aka 'unsigned char[*encoded_size]'}
211.2         316 |     uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(*encoded_size)]);
211.2             |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/encoder_dict.c -o bin/temp.linux-armv7l-cpython-311/c/enc/encode
r_dict.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/entropy_encode.c -o bin/temp.linux-armv7l-cpython-311/c/enc/entr
opy_encode.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/fast_log.c -o bin/temp.linux-armv7l-cpython-311/c/enc/fast_log.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/histogram.c -o bin/temp.linux-armv7l-cpython-311/c/enc/histogram
.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/literal_cost.c -o bin/temp.linux-armv7l-cpython-311/c/enc/litera
l_cost.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/memory.c -o bin/temp.linux-armv7l-cpython-311/c/enc/memory.o    
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/metablock.c -o bin/temp.linux-armv7l-cpython-311/c/enc/metablock
.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/static_dict.c -o bin/temp.linux-armv7l-cpython-311/c/enc/static_
dict.o
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c c/enc/utf8_util.c -o bin/temp.linux-armv7l-cpython-311/c/enc/utf8_util
.o
211.2       creating bin/temp.linux-armv7l-cpython-311/python
211.2       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ic/include -I/usr/local/include/python3.11 -c python/_brotli.cc -o bin/temp.linux-armv7l-cpython-311/python/_brotli.
o
211.2       gcc: fatal error: cannot execute 'cc1plus': execvp: No such file or directory
211.2       compilation terminated.
211.2       error: command '/usr/bin/gcc' failed with exit code 1
211.2       [end of output]
211.2
211.2   note: This error originates from a subprocess, and is likely not a problem with pip.
211.2   ERROR: Failed building wheel for Brotli
211.2   Running setup.py clean for Brotli
212.9   Building wheel for MarkupSafe (setup.py): started
218.8   Building wheel for MarkupSafe (setup.py): finished with status 'done'
218.8   Created wheel for MarkupSafe: filename=MarkupSafe-2.1.3-cp311-cp311-linux_armv7l.whl size=27249 sha256=d87469a24c8d7fb956740ed4425925e9e18271c3f4e6b247c1a0dee01921711d
218.8   Stored in directory: /root/.cache/pip/wheels/ff/e4/e3/cdbcd32a8d43739cd9dbbb864dec76f1416dcf4a8cb127fb39
218.9 Successfully built MarkupSafe
218.9 Failed to build Brotli
218.9 ERROR: Failed to build one or more wheels
```